### PR TITLE
Change button in sticky header to account login

### DIFF
--- a/src/wp-content/themes/tuleva/templates/header/main-sticky.php
+++ b/src/wp-content/themes/tuleva/templates/header/main-sticky.php
@@ -11,7 +11,7 @@
             <?php get_template_part('templates/header/menu'); ?>
             <div class="d-flex flex-column flex-md-row align-items-md-center ml-auto">
                 <?php language_picker(); ?>
-                <?php _e('<a href="/en/transfer-pension-tuleva/" class="btn btn-primary btn-block d-block d-md-none d-lg-block ml-md-2 mt-4 mt-md-0">Switch to Tuleva</a>', TEXT_DOMAIN); ?>
+                <a href="https://pension.tuleva.ee" class="btn btn-primary btn-block d-block d-md-block d-lg-block ml-md-2 mt-4 mt-md-0"><?php _e('Log in to account', TEXT_DOMAIN); ?></a>
             </div>
         </div>
     </nav>

--- a/src/wp-content/themes/tuleva/templates/header/main-sticky.php
+++ b/src/wp-content/themes/tuleva/templates/header/main-sticky.php
@@ -11,7 +11,7 @@
             <?php get_template_part('templates/header/menu'); ?>
             <div class="d-flex flex-column flex-md-row align-items-md-center ml-auto">
                 <?php language_picker(); ?>
-                <a href="https://pension.tuleva.ee" class="btn btn-primary btn-block d-block d-md-block d-lg-block ml-md-2 mt-4 mt-md-0"><?php _e('Log in to account', TEXT_DOMAIN); ?></a>
+                <a href="https://pension.tuleva.ee" class="btn btn-primary btn-block d-block d-md-block d-lg-block ml-md-2 mt-4 mt-md-0"><?php _e('Log in', TEXT_DOMAIN); ?></a>
             </div>
         </div>
     </nav>


### PR DESCRIPTION
Website has 2 headers - main and main-sticky.

Main contained pension account login button, whereas main-sticky, which appeared after scrolling down, transferred to fund choosing page after pressing same button.

New logic - login to pension account in both header versions.