### PR TITLE
Update Põhiteave document links to 19.03.2026

### DIFF
--- a/src/wp-content/themes/tuleva/templates/components/fund-bonds-details.php
+++ b/src/wp-content/themes/tuleva/templates/components/fund-bonds-details.php
@@ -61,7 +61,7 @@
                                 <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2025/07/20250301_Mudelportfell_Tuleva.pdf" target="_blank"><?php _e('Model portfolio', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
                             </li>
                             <li>
-                                <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/03/Pohiteave-TUK00-kehtib-alates-02.03.2026.pdf" target="_blank"><?php _e('Key Investor Information', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
+                                <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/03/Pohiteave-TUK00-kehtib-alates-19.03.2026.pdf" target="_blank"><?php _e('Key Investor Information', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
                             </li>
                             <li>
                                 <a href="<?php echo get_nav_procedure_document_url(); ?>" target="_blank"><?php _e('Procedure for determining net worth of fund', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>

--- a/src/wp-content/themes/tuleva/templates/components/fund-stocks-details.php
+++ b/src/wp-content/themes/tuleva/templates/components/fund-stocks-details.php
@@ -60,7 +60,7 @@
                                 <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2025/07/20250301_Mudelportfell_Tuleva.pdf" target="_blank"><?php _e('Model portfolio', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
                             </li>
                             <li>
-                                <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/03/Pohiteave-TUK75-kehtib-alates-02.03.2026.pdf" target="_blank"><?php _e('Key Investor Information', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
+                                <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/03/Pohiteave-TUK75-kehtib-alates-19.03.2026-.pdf" target="_blank"><?php _e('Key Investor Information', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
                             </li>
                             <li>
                                 <a href="<?php echo get_nav_procedure_document_url(); ?>" target="_blank"><?php _e('Procedure for determining net worth of fund', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>

--- a/src/wp-content/themes/tuleva/templates/components/fund-third-details.php
+++ b/src/wp-content/themes/tuleva/templates/components/fund-third-details.php
@@ -60,7 +60,7 @@
                                 <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2025/07/20250301_Mudelportfell_Tuleva.pdf" target="_blank"><?php _e('Model portfolio', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
                             </li>
                             <li>
-                                <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/03/Pohiteave-TUV100-kehtib-alates-02.03.2026.pdf" target="_blank"><?php _e('Key Investor Information', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
+                                <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/03/Pohiteave-TUV100-kehtib-alates-19.03.2026.pdf" target="_blank"><?php _e('Key Investor Information', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
                             </li>
                             <li>
                                 <a href="<?php echo get_nav_procedure_document_url(); ?>" target="_blank"><?php _e('Procedure for determining net worth of fund', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>


### PR DESCRIPTION
## Summary
- Update Key Investor Information (Põhiteave) links for TUK75, TUK00, and TUV100 to 19.03.2026 versions
- PDFs already uploaded to WordPress media library

## Test plan
- [ ] Verify links on fund pages point to correct 19.03.2026 documents after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)