### PR TITLE
TKF100: add upcoming documents (effective 12.06.2026)

### DIFF
--- a/src/wp-content/themes/tuleva/helpers/acf/fund-savings.php
+++ b/src/wp-content/themes/tuleva/helpers/acf/fund-savings.php
@@ -268,6 +268,28 @@ acf_add_local_field_group(array (
             'instructions' => 'Link to previous reports archive (external URL)',
             'required' => 0,
         ),
+        array (
+            'key' => 'field_fund_savings_prospectus_upcoming',
+            'label' => 'Prospectus (Upcoming)',
+            'name' => 'prospectus_upcoming_file',
+            'type' => 'file',
+            'instructions' => 'Upcoming prospectus PDF — shown alongside the current one. The file title from the media library is used as the link label (e.g. "TKF100 Prospekt - kehtib alates 12.06.2026").',
+            'required' => 0,
+            'return_format' => 'array',
+            'library' => 'all',
+            'mime_types' => 'pdf',
+        ),
+        array (
+            'key' => 'field_fund_savings_terms_upcoming',
+            'label' => 'Terms and Conditions (Upcoming)',
+            'name' => 'terms_upcoming_file',
+            'type' => 'file',
+            'instructions' => 'Upcoming terms and conditions PDF — shown alongside the current one. The file title from the media library is used as the link label.',
+            'required' => 0,
+            'return_format' => 'array',
+            'library' => 'all',
+            'mime_types' => 'pdf',
+        ),
     ),
     'location' => array (
         array (

--- a/src/wp-content/themes/tuleva/templates/components/fund-savings-details.php
+++ b/src/wp-content/themes/tuleva/templates/components/fund-savings-details.php
@@ -14,6 +14,8 @@ $fund_co2_intensity = get_field('fund_co2_intensity');
 // Documents (file fields return URL directly)
 $prospectus_url = get_field('prospectus_file');
 $terms_url = get_field('terms_file');
+$prospectus_upcoming = get_field('prospectus_upcoming_file');
+$terms_upcoming = get_field('terms_upcoming_file');
 $model_portfolio_url = get_field('model_portfolio_file');
 $key_investor_info_url = get_field('key_investor_info_file');
 $investment_report_url = get_field('investment_report_file');
@@ -104,6 +106,18 @@ $investor_rights_url = get_field('investor_rights_file');
                                            target="_blank"><?php _e('Terms and conditions', TEXT_DOMAIN) ?></a>
                                     <?php endif; ?>
                                     <?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
+                                    <?php if ($prospectus_upcoming || $terms_upcoming): ?>
+                                        <br>
+                                        <?php if ($prospectus_upcoming): ?>
+                                            <a href="<?php echo esc_url($prospectus_upcoming['url']); ?>"
+                                               target="_blank"><?php echo esc_html($prospectus_upcoming['title']); ?></a>
+                                        <?php endif; ?>
+                                        <?php if ($prospectus_upcoming && $terms_upcoming): _e(' and ', TEXT_DOMAIN); endif; ?>
+                                        <?php if ($terms_upcoming): ?>
+                                            <a href="<?php echo esc_url($terms_upcoming['url']); ?>"
+                                               target="_blank"><?php echo esc_html($terms_upcoming['title']); ?></a>
+                                        <?php endif; ?>
+                                    <?php endif; ?>
                                 </li>
                             <?php endif; ?>
                             <?php if ($model_portfolio_url): ?>


### PR DESCRIPTION
## Summary

- Adds two new ACF fields to `helpers/acf/fund-savings.php`: `prospectus_upcoming_file` and `terms_upcoming_file`
- Updates `templates/components/fund-savings-details.php` to show upcoming documents as a sub-line within the existing Prospectus/Terms list item (no separate bullet, no "(in Estonian)" suffix)

## PDFid on juba meediakogus

- Prospekt (id 36880): https://tuleva.ee/wp-content/uploads/2026/05/TKF100-Prospekt-kehtib-alates-12.06.2026.pdf
- Tingimused (id 36883): https://tuleva.ee/wp-content/uploads/2026/05/TKF100-Tingimused-kehtib-alates-12.06.2026.pdf

## Pärast merge'i — wp-adminis

1. Mine https://tuleva.ee/wp-admin/post.php?post=35292&action=edit
2. **Prospectus (Upcoming)** → otsi `TKF100-Prospekt-kehtib-alates-12.06.2026` → vali
3. **Terms and Conditions (Upcoming)** → otsi `TKF100-Tingimused-kehtib-alates-12.06.2026` → vali
4. **Update**

## 12.06.2026 aktiveerumisel

Uuenda `prospectus_file` ja `terms_file` uutele failidele ning tühjenda `prospectus_upcoming_file` ja `terms_upcoming_file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)