### PR TITLE
Update investment report links for aprill 2026

### DIFF
--- a/src/wp-content/themes/tuleva/templates/components/fund-bonds-details.php
+++ b/src/wp-content/themes/tuleva/templates/components/fund-bonds-details.php
@@ -80,7 +80,7 @@
                         <h2 class="mt-5 mb-4 h4"><?php _e('Reports', TEXT_DOMAIN) ?></h2>
                         <ul class="list-style-arrow text-secondary">
                             <li>
-                                <?php echo generate_report_link('https://tuleva.ee/wp-content/uploads/2026/04/Tuleva-Maailma-Volakirjade-Pensionifondi-investeeringute-aruanne-marts-2026.pdf',__('Investment reports', TEXT_DOMAIN)); ?><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
+                                <?php echo generate_report_link('https://tuleva.ee/wp-content/uploads/2026/05/Tuleva-Maailma-Volakirjade-Pensionifondi-investeeringute-aruanne-aprill-2026.pdf',__('Investment reports', TEXT_DOMAIN)); ?><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
                                 <br>
                                 <a href="https://www.pensionikeskus.ee/ii-sammas/kohustuslikud-pensionifondid/fid/76/" target="_blank"><?php _e('Previous reports', TEXT_DOMAIN) ?></a>
                             </li>

--- a/src/wp-content/themes/tuleva/templates/components/fund-stocks-details.php
+++ b/src/wp-content/themes/tuleva/templates/components/fund-stocks-details.php
@@ -79,7 +79,7 @@
                         <h2 class="mt-5 mb-4 h4"><?php _e('Reports', TEXT_DOMAIN) ?></h2>
                         <ul class="list-style-arrow mb-5 text-secondary">
                             <li>
-                                <?php echo generate_report_link('https://tuleva.ee/wp-content/uploads/2026/04/Tuleva-Maailma-Aktsiate-Pensionifondi-investeeringute-aruanne-marts-2026.pdf',__('Investment reports', TEXT_DOMAIN)); ?><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
+                                <?php echo generate_report_link('https://tuleva.ee/wp-content/uploads/2026/05/Tuleva-Maailma-Aktsiate-Pensionifondi-investeeringute-aruanne-aprill-2026.pdf',__('Investment reports', TEXT_DOMAIN)); ?><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
                                 <br>
                                 <a href="https://www.pensionikeskus.ee/ii-sammas/kohustuslikud-pensionifondid/fid/77/" target="_blank"><?php _e('Previous reports', TEXT_DOMAIN) ?></a>
                             </li>

--- a/src/wp-content/themes/tuleva/templates/components/fund-third-details.php
+++ b/src/wp-content/themes/tuleva/templates/components/fund-third-details.php
@@ -79,7 +79,7 @@
                         <h2 class="mt-5 mb-4 h4"><?php _e('Reports', TEXT_DOMAIN) ?></h2>
                         <ul class="list-style-arrow text-secondary">
                             <li>
-                                <?php echo generate_report_link('https://tuleva.ee/wp-content/uploads/2026/04/Tuleva-III-Samba-Pensionifondi-investeeringute-aruanne-marts-2026.pdf',__('Investment reports', TEXT_DOMAIN)); ?><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
+                                <?php echo generate_report_link('https://tuleva.ee/wp-content/uploads/2026/05/Tuleva-III-Samba-Pensionifondi-investeeringute-aruanne-aprill-2026.pdf',__('Investment reports', TEXT_DOMAIN)); ?><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
                                 <br>
                                 <a href="https://www.pensionikeskus.ee/iii-sammas/vabatahtlikud-fondid/fid/81/" target="_blank"><?php _e('Previous reports', TEXT_DOMAIN) ?></a>
                             </li>


### PR DESCRIPTION
Updates investment report URLs for aprill 2026.

Auto-generated by `investeeringute_aruanne.gs`.

Files updated:
- `src/wp-content/themes/tuleva/templates/components/fund-bonds-details.php`
- `src/wp-content/themes/tuleva/templates/components/fund-stocks-details.php`
- `src/wp-content/themes/tuleva/templates/components/fund-third-details.php`