### PR TITLE
Expose savings fund document fields over REST

### DIFF
--- a/src/wp-content/themes/tuleva/helpers/acf/fund-savings.php
+++ b/src/wp-content/themes/tuleva/helpers/acf/fund-savings.php
@@ -306,6 +306,7 @@ acf_add_local_field_group(array (
     'label_placement' => 'top',
     'instruction_placement' => 'label',
     'active' => 1,
+    'show_in_rest' => 1,
 ));
 
 endif;


### PR DESCRIPTION
## What

Enable `show_in_rest` on the `group_fund_savings_documents` ACF field group so the current TKF document URLs — `terms_file`, `prospectus_file`, `key_investor_info_file` (all `return_format => 'url'`) — are readable via the WordPress REST API:

```
GET /wp-json/wp/v2/pages?slug=tuleva-taiendav-kogumisfond-dokumendid → .acf.terms_file, …
```

## Why

The onboarding-client drift check needs to compare the documents shown in the savings-fund signing flow against the ones published here. Exposing these fields over REST lets it read them as structured data instead of scraping the rendered page (no fragile filename/label parsing). See TulevaEE/onboarding-client#1555.

## Safety

- Additive only — one field-group flag, no template or UI change.
- The exposed values are document URLs that are **already public** (linked on the public fund-documents page), so no new information is disclosed.
- Deploy remains `master`-only; merging this and pushing to master is what makes it live.

Refs TulevaEE/TKF-VPII2026#63

🤖 Generated with [Claude Code](https://claude.com/claude-code)
