### PR TITLE
Open FAQ accordion when linked via URL hash

### DIFF
--- a/src/wp-content/themes/tuleva/js/main.js
+++ b/src/wp-content/themes/tuleva/js/main.js
@@ -413,6 +413,28 @@ $(document).ready(function ($) {
 
                     targetElement.click();
                 }
+
+                const qaToggle = document.querySelector(`#${hash} > a.qa__question[data-bs-toggle="collapse"]`);
+
+                if (qaToggle) {
+                    const collapsedWrapper = qaToggle.closest('.qa__question-wrapper--collapsed');
+                    if (collapsedWrapper) {
+                        const block = collapsedWrapper.closest('.qa-block');
+                        if (block) {
+                            block.querySelectorAll('.qa__question-wrapper--collapsable')
+                                .forEach(el => el.classList.remove('qa__question-wrapper--collapsed'));
+                            const expandLink = block.querySelector('.qa-block__expand');
+                            if (expandLink) {
+                                expandLink.classList.add('more');
+                                expandLink.textContent = expandLink.dataset.closeText;
+                            }
+                        }
+                    }
+                    qaToggle.click();
+                    setTimeout(() => {
+                        qaToggle.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    }, 200);
+                }
             }
         },
         initCountdownTimer = function () {


### PR DESCRIPTION
## Summary
- On page load, automatically open the FAQ question targeted by the URL hash (`#kkk-N` for qa-block, `#accordion-block-N` for accordion-block)
- Previously `#kkk-4` only scrolled to the question but kept the accordion collapsed — it now opens it
- If the target question lives inside the "More questions" hidden section, expand that section first

Motivation: lets us share links (e.g. in newsletters or support replies) that open a specific FAQ directly, without requiring an extra click.

## Test plan
- [ ] Open [/iii-samba-sissemakse-info/#kkk-4](https://tuleva.ee/iii-samba-sissemakse-info/#kkk-4) — the question "Kus ma leian oma III samba püsimakse?" should be open and scrolled into view
- [ ] Open the same page without a hash — nothing should change, all questions stay collapsed
- [ ] Verify existing `.toggle-parent` anchor links still work (e.g. on the front page)
- [ ] On a page with >10 questions, linking to a hidden question should also expand the "More questions" section