### PR TITLE
Match accordion block question font to Q&A block

### DIFF
--- a/src/wp-content/themes/tuleva/templates/components/accordion-block.php
+++ b/src/wp-content/themes/tuleva/templates/components/accordion-block.php
@@ -14,7 +14,7 @@
                            data-bs-target="#collapsed-text-<?php echo $i; ?>"
                            aria-expanded="true"
                            aria-controls="collapsed-text-<?php echo $i; ?>">
-                            <p class="m-0 fs-4 lh-sm"><?php the_sub_field('title'); ?></p>
+                            <p class="m-0"><?php the_sub_field('title'); ?></p>
                             <?php if (get_sub_field('lead_text')) { ?>
                                 <p class="m-0 mt-2 fs-6 fw-normal"><?php the_sub_field('lead_text'); ?></p>
                             <?php } ?>


### PR DESCRIPTION
## What

Removes the `fs-4` (1.5rem) class from the accordion block question title so it inherits the `.qa__question` size (**1.125rem, weight 500**) — the same as the Q&A block. Accordion questions are now visually consistent with the Q&A block across the site.

## Why

We need a page with FAQs split into two categories. The Q&A block has a hardcoded heading ("Korduma Kippuvad Küsimused") that can't be edited or split into categories. The accordion block allows custom headings above it, but its question font was larger. This PR aligns the font.

## Impact (verified)

The accordion block is currently used on 3 pages — the question font will shrink there from 1.5rem to 1.125rem:
- `/taiendav-kogumisfond/` (15 questions)
- `/tasud-alla/` (4)
- `/en/tasud-alla/` (4)

## Risk checks

- Diff = 1 line (PHP template only, no SCSS recompile needed)
- No CSS rule sets a font size on `p` in the qa context → clean inheritance
- IDs (`accordion-block-N`, `collapsed-text-N`) unchanged → #68 URL-hash feature still works
- `npm test` does not touch templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)