### PR TITLE
Update remuneration policy document to 11.06.2026 version

### DIFF
--- a/src/wp-content/themes/tuleva/helpers/extras.php
+++ b/src/wp-content/themes/tuleva/helpers/extras.php
@@ -386,7 +386,7 @@ function get_esg_factors_document_url() {
 }
 
 function get_remuneration_document_url() {
-    $remuneration_document_path = '/wp-content/uploads/2025/08/Tuleva-Fondid-AS-tasustamise-pohimotted-2025_august.pdf';
+    $remuneration_document_path = '/wp-content/uploads/2026/06/Tuleva-Fondid-AS-tasustamise-pohimotted-11.06.2026.pdf';
 
     return get_site_url() . $remuneration_document_path;
 }


### PR DESCRIPTION
Replaces the "Remuneration Policy of Tuleva Fondid AS" PDF on the
TUK75, TUK00, TUV100 and TKF100 fund detail pages — from the
August 2025 version to the 11.06.2026 version.

PDF is already uploaded to the media library:
https://tuleva.ee/wp-content/uploads/2026/06/Tuleva-Fondid-AS-tasustamise-pohimotted-11.06.2026.pdf
