### PR TITLE
Update model portfolio document to 17.06.2026 version

### DIFF
--- a/src/wp-content/themes/tuleva/templates/components/fund-bonds-details.php
+++ b/src/wp-content/themes/tuleva/templates/components/fund-bonds-details.php
@@ -58,7 +58,7 @@
                                 <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/03/TUK75-ja-TUK00-Prospekt-kehtib-alates-02.03.2026.pdf" target="_blank"><?php _e('Prospectus', TEXT_DOMAIN) ?></a><?php _e(' and ', TEXT_DOMAIN) ?><a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/03/Tuleva-Maailma-Volakirjade-Pensionifond-tingimused-kehtib-alates-02.03.2026.pdf" target="_blank"><?php _e('Terms and conditions', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
                             </li>
                             <li>
-                                <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/03/Mudelportfelli-avalikustamiseks-27.03.2026-seisuga.pdf" target="_blank"><?php _e('Model portfolio', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
+                                <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/06/Mudelportfell-avalikustamiseks-17.06.2026-seisuga.pdf" target="_blank"><?php _e('Model portfolio', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
                             </li>
                             <li>
                                 <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/03/Pohiteave-TUK00-kehtib-alates-19.03.2026.pdf" target="_blank"><?php _e('Key Investor Information', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>

--- a/src/wp-content/themes/tuleva/templates/components/fund-stocks-details.php
+++ b/src/wp-content/themes/tuleva/templates/components/fund-stocks-details.php
@@ -57,7 +57,7 @@
                                 <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/03/TUK75-ja-TUK00-Prospekt-kehtib-alates-02.03.2026.pdf" target="_blank"><?php _e('Prospectus', TEXT_DOMAIN) ?></a><?php _e(' and ', TEXT_DOMAIN) ?><a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/03/Tuleva-Maailma-Aktsiate-Pensionifondi-tingimused-kehtib-alates-02.03.2026.pdf" target="_blank"><?php _e('Terms and conditions', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
                             </li>
                             <li>
-                                <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/03/Mudelportfelli-avalikustamiseks-27.03.2026-seisuga.pdf" target="_blank"><?php _e('Model portfolio', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
+                                <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/06/Mudelportfell-avalikustamiseks-17.06.2026-seisuga.pdf" target="_blank"><?php _e('Model portfolio', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
                             </li>
                             <li>
                                 <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/03/Pohiteave-TUK75-kehtib-alates-19.03.2026-.pdf" target="_blank"><?php _e('Key Investor Information', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>

--- a/src/wp-content/themes/tuleva/templates/components/fund-third-details.php
+++ b/src/wp-content/themes/tuleva/templates/components/fund-third-details.php
@@ -57,7 +57,7 @@
                                 <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/03/TUV100-Prospekt-kehtib-alates-02.03.2026.pdf" target="_blank"><?php _e('Prospectus', TEXT_DOMAIN) ?></a><?php _e(' and ', TEXT_DOMAIN) ?><a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/03/Tuleva-III-Samba-Pensionifondi-tingimused-kehtib-alates-02.03.2026.pdf" target="_blank"><?php _e('Terms and conditions', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
                             </li>
                             <li>
-                                <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/03/Mudelportfelli-avalikustamiseks-27.03.2026-seisuga.pdf" target="_blank"><?php _e('Model portfolio', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
+                                <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/06/Mudelportfell-avalikustamiseks-17.06.2026-seisuga.pdf" target="_blank"><?php _e('Model portfolio', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>
                             </li>
                             <li>
                                 <a href="<?php echo get_site_url(); ?>/wp-content/uploads/2026/03/Pohiteave-TUV100-kehtib-alates-19.03.2026.pdf" target="_blank"><?php _e('Key Investor Information', TEXT_DOMAIN) ?></a><?php _e(' (in Estonian)', TEXT_DOMAIN) ?>


### PR DESCRIPTION
Replaces the model portfolio PDF link on TUK75, TUK00 and TUV100 fund
detail pages — from the 27.03.2026 version to the 17.06.2026-seisuga version.

TKF100 uses an ACF field for the model portfolio and is updated separately
via wp-admin (post 35292), not in this PR.

PDF is already uploaded to the media library:
https://tuleva.ee/wp-content/uploads/2026/06/Mudelportfell-avalikustamiseks-17.06.2026-seisuga.pdf