### PR TITLE
Fix ESG factors PDF URL — broken after media re-upload

### DIFF
--- a/src/wp-content/themes/tuleva/helpers/extras.php
+++ b/src/wp-content/themes/tuleva/helpers/extras.php
@@ -380,7 +380,7 @@ function get_nav_procedure_document_url() {
 }
 
 function get_esg_factors_document_url() {
-    $esg_factors_document_path = '/wp-content/uploads/2026/06/Investeerimisotsuste-poolt-kestlikkusteguritele-avaldatava-negatiivse-moju-mittearvestamine_16.06.2026.pdf';
+    $esg_factors_document_path = '/wp-content/uploads/2026/06/Investeerimisotsuste-poolt-kestlikkusteguritele-avaldatava-negatiivse-moju-mittearvestamine_16.06.2026-1.pdf';
 
     return get_site_url() . $esg_factors_document_path;
 }


### PR DESCRIPTION
Hotfix — the previously published PDF was the wrong file and was
replaced in the WP media library. WordPress assigned the new upload
a -1 suffix because the original slug was still reserved.

Without this fix, the "Non-consideration of adverse impacts of
investment decisions on sustainability factors" link on all four fund
pages is broken (points to a deleted file).

Correct PDF location:
https://tuleva.ee/wp-content/uploads/2026/06/Investeerimisotsuste-poolt-kestlikkusteguritele-avaldatava-negatiivse-moju-mittearvestamine_16.06.2026-1.pdf
